### PR TITLE
Make sure the devutils rspec file are loaded before anything else

### DIFF
--- a/spec/codecs/edn_spec.rb
+++ b/spec/codecs/edn_spec.rb
@@ -1,3 +1,4 @@
+require "logstash/devutils/rspec/spec_helper"
 require "logstash/codecs/edn"
 require "logstash/event"
 require "logstash/json"


### PR DESCRIPTION
To make this build work with different version of logstash we need to
make sure the rspec helpers are loaded before anything else.

Fixes: #2
